### PR TITLE
add PHASE + change default precision

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -939,7 +939,7 @@ pub mod {} {{
                 writeln!(&mut s, r##"
                 Value::{}(_) => {{
                     write!(
-                        f, "{{:.2}}{}",
+                        f, "{{:.3}}{}",
                         crate::Value::raw(self) as f32 / ({}_f32)
                     )
                 }}"##, f, u.suffix(), factor)?;
@@ -949,7 +949,7 @@ pub mod {} {{
                 writeln!(&mut s, r##"
                 Value::{}(_) => {{
                     write!(
-                        f, "{{:.2}}{}",
+                        f, "{{:.3}}{}",
                         ({}_f32).powi(crate::Value::raw(self) as i32) /
                         ({}_f32)
                     )
@@ -1436,7 +1436,7 @@ pub mod {} {{
 
     impl core::fmt::Display for Value {{
         fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {{
-            write!(f, "{{:.2}}{}", self.0.0)
+            write!(f, "{{:.3}}{}", self.0.0)
         }}
     }}
 

--- a/src/commands.ron
+++ b/src/commands.ron
@@ -229,6 +229,7 @@
 
     numerics: [
         ("PAGE", Raw, Unitless),
+        ("PHASE", Raw, Unitless),
         ("VOUT_COMMAND", VOutMode(Unsigned), Volts),
         ("VOUT_TRIM", VOutMode(Signed), Volts),
         ("VOUT_CAL_OFFSET", VOutMode(Signed), Volts),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,3 +393,9 @@ impl ULinear16 {
         }
     }
 }
+
+///
+/// A phase for purposes of the PHASE command
+///
+#[derive(Copy, Clone, Debug)]
+pub struct Phase(pub u8);

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -360,6 +360,29 @@ fn page() {
     assert_eq!(data.0, 0xde);
 }
 
+#[test]
+fn phase() {
+    use commands::PHASE::*;
+
+    let mut data = CommandData(1);
+    assert_eq!(data.0, 1);
+
+    let rval = data.mutate(mode, |field, _| {
+        assert_eq!(field.bitfield(), false);
+        Some(Replacement::Integer(0xf00))
+    });
+
+    assert_eq!(rval, Err(Error::OverflowReplacement));
+
+    let rval = data.mutate(mode, |field, _| {
+        assert_eq!(field.bitfield(), false);
+        Some(Replacement::Integer(0xde))
+    });
+
+    assert_eq!(rval, Ok(()));
+    assert_eq!(data.0, 0xde);
+}
+
 fn dump_data(
     val: u32,
     width: Bitwidth,


### PR DESCRIPTION
Commit message:

```
This adds support for the PHASE command as well as changes the default
precision of numerical display to support oxidecomputer/humility#338.
```