### PR TITLE
Make build output reproducible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "pmbus"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmbus"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"


### PR DESCRIPTION
The build code iterates over HashMaps to generate output. This is correct but may not always generate the same output depending on hashing. This can produce slightly different generated code. Ensure the output is stable by sorting before outputing. We don't actually care what the order is, just that it happens the same way every time.