### PR TITLE
mwocp68: add commands for firmware update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: 1.81.0
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -51,7 +51,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: 1.81.0
           override: true
       - uses: Swatinem/rust-cache@v1
       - uses: actions-rs/cargo@v1
@@ -69,7 +69,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: 1.57.0
+          toolchain: 1.81.0
           override: true
           components: clippy
       - uses: Swatinem/rust-cache@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "pmbus"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmbus"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 pmbus: A crate for PMBus manipulation
 
 This is a no_std crate that expresses the PMBus protocol, as described in
-the PMBus 1.3 specifcation.  This crate is intended to be generic with
+the PMBus 1.3 specification.  This crate is intended to be generic with
 respect to implementation and usable by software that will directly
 communicate with PMBus devices via SMBus/I2C as well as by software that
 merely wishes to make sense of the PMBus protocol (e.g., debuggers or

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
-channel = "nightly-2024-04-04"
+channel = "1.81.0"
+components = ["clippy"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ impl Linear11 {
 
         let n = f32::ceil(libm::log2f(n)) as i16;
 
-        if n < LINEAR11_N_MIN || n > LINEAR11_N_MAX {
+        if !(LINEAR11_N_MIN..=LINEAR11_N_MAX).contains(&n) {
             None
         } else {
             let exp = f32::powi(2.0, n.into());
@@ -386,7 +386,7 @@ impl ULinear16 {
     pub fn from_real(x: f32, exp: ULinear16Exponent) -> Option<Self> {
         let val = (x / f32::powi(2.0, exp.0.into())).round();
 
-        if val > core::u16::MAX as f32 {
+        if val > u16::MAX as f32 {
             None
         } else {
             Some(Self(val as u16, exp))

--- a/src/mwocp68.ron
+++ b/src/mwocp68.ron
@@ -114,20 +114,44 @@
         },
 
         "BOOT_LOADER_STATUS": {
-            "ProgramBusy": (
-                name: "Write operation in progress",
-                bits: Bit(7),
+            "ChecksumSuccessful": (
+                name: "Checksum successfully checked",
+                bits: Bit(0),
                 values: Sentinels({
-                    "NotInProgress": (0b0, "not in progress"),
-                    "InProgress": (0b1, "in progress"),
+                    "NotSuccessful": (0b0, "not successful"),
+                    "Successful": (0b1, "successful"),
                 }),
             ),
-            "Mode": (
-                name: "Boot loader mode",
-                bits: Bit(6),
+            "MemoryError": (
+                name: "Memory boundary error condition",
+                bits: Bit(1),
                 values: Sentinels({
-                    "NotBootLoader": (0b0, "not in boot loader"),
-                    "BootLoader": (0b1, "in boot loader"),
+                    "NoError": (0b0, "no error"),
+                    "Error": (0b1, "error"),
+                }),
+            ),
+            "AlignError": (
+                name: "Unaligned memory read/write",
+                bits: Bit(2),
+                values: Sentinels({
+                    "NoError": (0b0, "no error"),
+                    "Error": (0b1, "error"),
+                }),
+            ),
+            "KeyError": (
+                name: "Invalid key detected",
+                bits: Bit(3),
+                values: Sentinels({
+                    "NoError": (0b0, "no error"),
+                    "Error": (0b1, "error"),
+                }),
+            ),
+            "StartError": (
+                name: "PSU failed to start",
+                bits: Bit(4),
+                values: Sentinels({
+                    "NoError": (0b0, "no error"),
+                    "Error": (0b1, "error"),
                 }),
             ),
             "ProductKeyError": (
@@ -138,8 +162,22 @@
                     "Error": (0b1, "error"),
                 }),
             ),
-
-
+            "Mode": (
+                name: "Boot loader mode",
+                bits: Bit(6),
+                values: Sentinels({
+                    "NotBootLoader": (0b0, "not in boot loader"),
+                    "BootLoader": (0b1, "in boot loader"),
+                }),
+            ),
+            "ProgramBusy": (
+                name: "Write operation in progress",
+                bits: Bit(7),
+                values: Sentinels({
+                    "NotInProgress": (0b0, "not in progress"),
+                    "InProgress": (0b1, "in progress"),
+                }),
+            ),
         }
     }
 )

--- a/src/mwocp68.ron
+++ b/src/mwocp68.ron
@@ -1,8 +1,41 @@
 (
     all: [
+        //
+        // MFR_PAGE_X allows for reading the black box data: when any fault
+        // (except for an input undervoltage) occurs, many values are latched
+        // into non-volatile memory.  To read these values, the desired fault
+        // recency should be written to MFR_PAGE_X, after which the following
+        // standard PMBus commands can be issued to determine the corresponding
+        // value at the time of the fault:
+        //
+        //   STATUS_VOUT            STATUS_FANS_1_2        READ_TEMPERATURE_2
+        //   STATUS_IOUT            READ_VIN               READ_TEMPERATURE_3
+        //   STATUS_INPUT           READ_IIN               READ_FAN_SPEED_1
+        //   STATUS_TEMPERATURE     READ_VOUT              READ_POUT
+        //   STATUS_CML             READ_IOUT              READ_PIN
+        //   STATUS_MFR_SPECIFIC    READ_TEMPERATURE_1
+        //
         (0xe4, "MFR_PAGE_X", WriteByte, ReadByte),
         (0xf0, "BOOT_LOADER_KEY", WriteBlock, Illegal),
+
+        //
+        // Note that BOOT_LOADER_CMD shares the same command code as
+        // BOOT_LOADER_STATUS (!!), with the sense depending if it's a read
+        // (BOOT_LOADER_STATUS) or a write (BOOT_LOADER_CMD).  We don't support
+        // the notion of a single command code having multiple senses based on
+        // operation, but if we did we might have an additional line here:
+        //
+        //   (0xf1, "BOOT_LOADER_CMD", WriteBlock, Illegal)
+        //
+        // This behavior is not PMBus compliant (such that compliance with such
+        // a loose specification in fact means anything at all), so it's
+        // unclear if our implicit refusal to accommodate it isn't a feature.
+        // (And as long as we're editorializing: that both commands use block
+        // operations for a fixed-size one-byte payload is... idiosyncratic, to
+        // put it euphemistically.)
+        //
         (0xf1, "BOOT_LOADER_STATUS", Illegal, ReadBlock),
+
         (0xf2, "BOOT_LOADER_MEMORY_BLOCK", MfrDefined, MfrDefined),
         (0xf3, "BOOT_LOADER_PRODUCT_KEY", MfrDefined, Illegal),
         (0xf4, "IMAGE_CHECKSUM", WriteBlock, Illegal),

--- a/src/mwocp68.ron
+++ b/src/mwocp68.ron
@@ -1,5 +1,13 @@
 (
-    all: [],
+    all: [
+        (0xe4, "MFR_PAGE_X", WriteByte, ReadByte),
+        (0xf0, "BOOT_LOADER_KEY", WriteBlock, Illegal),
+        (0xf1, "BOOT_LOADER_STATUS", Illegal, ReadBlock),
+        (0xf2, "BOOT_LOADER_MEMORY_BLOCK", MfrDefined, MfrDefined),
+        (0xf3, "BOOT_LOADER_PRODUCT_KEY", MfrDefined, Illegal),
+        (0xf4, "IMAGE_CHECKSUM", WriteBlock, Illegal),
+    ],
+
     numerics: [
         ("FAN_COMMAND_1", Linear11, Percent),
         ("FAN_COMMAND_2", Linear11, Percent),
@@ -35,6 +43,7 @@
         ("MFR_MAX_TEMP_2", Linear11, Celsius),
         ("MFR_MAX_TEMP_3", Linear11, Celsius),
     ],
+
     structured: {
         "STATUS_MFR_SPECIFIC": {
             // Bit 7: reserved
@@ -88,5 +97,49 @@
                 }),
             ),
         },
+
+        "MFR_PAGE_X": {
+            "MFQPage": (
+                name: "Murata-defined PMBus page",
+                bits: Bitrange(High(7), Low(0)),
+                values: Sentinels({
+                    "RealTimeData": (0xff, "Default, normal operation"),
+                    "FaultHistory1": (0x00, "most recent fault"),
+                    "FaultHistory2": (0x01, "next most recent fault"),
+                    "FaultHistory3": (0x02, "third most recent fault"),
+                    "FaultHistory4": (0x03, "fourth most recent fault"),
+                    "FaultHistory5": (0x04, "oldest fault"),
+                })
+            )
+        },
+
+        "BOOT_LOADER_STATUS": {
+            "ProgramBusy": (
+                name: "Write operation in progress",
+                bits: Bit(7),
+                values: Sentinels({
+                    "NotInProgress": (0b0, "not in progress"),
+                    "InProgress": (0b1, "in progress"),
+                }),
+            ),
+            "Mode": (
+                name: "Boot loader mode",
+                bits: Bit(6),
+                values: Sentinels({
+                    "NotBootLoader": (0b0, "not in boot loader"),
+                    "BootLoader": (0b1, "in boot loader"),
+                }),
+            ),
+            "ProductKeyError": (
+                name: "Product key verification error",
+                bits: Bit(5),
+                values: Sentinels({
+                    "NoError": (0b0, "no error"),
+                    "Error": (0b1, "error"),
+                }),
+            ),
+
+
+        }
     }
 )


### PR DESCRIPTION
Draft comments:

```
This adds some additional PMBus support for the MWOCP68-3600 series,
specifically around the commands necessary to support firmware update.
(This also performs some minor cleanup, bumping the Rust version
to 1.84 and fixing the resulting clippy warnings.)
```
