### PR TITLE
fix invalid sentinel values + ADM1272 OPERATION definition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,7 +107,7 @@ dependencies = [
 
 [[package]]
 name = "pmbus"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "anyhow",
  "convert_case",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pmbus"
-version = "0.1.6"
+version = "0.1.7"
 authors = ["Bryan Cantrill <bryan@oxide.computer>"]
 edition = "2018"
 license = "MPL-2.0"

--- a/build.rs
+++ b/build.rs
@@ -1154,7 +1154,7 @@ pub mod {} {{
                 Field::{f} => {{
                     match {f}::from_u{bits}(raw) {{
                         Some(t) => Ok(Value::{f}(t)),
-                        None => Err(Error::InvalidSentinel),
+                        None => Ok(Value::Unknown(raw)),
                     }}
                 }}"##)?;
     }

--- a/src/adm1272.ron
+++ b/src/adm1272.ron
@@ -1,5 +1,6 @@
 (
     all: [
+        (0x01, "OPERATION", WriteByte, ReadByte),
         (0x20, "VOUT_MODE", Illegal, Illegal),
         (0xcc, "RESTART_TIME", WriteByte, ReadByte),
         (0xd0, "PEAK_IOUT", WriteWord, ReadWord),
@@ -46,6 +47,24 @@
     ],
 
     structured: {
+	// The ADM1272 regrettably doesn't support the full PMBus OPERATION
+	// command (it only supports OnOffState) -- and in particular, its
+	// default value of 0x80 corresponds to an illegal value for
+	// MarginFaultResponse (for which only 0b01 and 0b10 are defined
+	// values). To prevent interpretation of any illegal fields, we
+	// therefore redefine OPERATION here to contain *only* OnOffState.
+	//
+        "OPERATION": {
+            "OnOffState": (
+                name: "On/off state",
+                bits: Bit(7),
+                values: Sentinels({
+                    "Off": (0, "output off"),
+                    "On": (1, "output on"),
+                }),
+            ),
+	},
+
         "STATUS_MFR_SPECIFIC": {
             "FETHealthFault": (
                 name: "FET health fault",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,8 +111,6 @@ pub enum Error {
     ValueOutOfRange,
     /// Specified VOutMode is not valid
     InvalidMode,
-    /// Value in the field did not correspond to a known sentinel value
-    InvalidSentinel,
     /// VOutMode indicates Direct, but device has no known coefficients
     MissingCoefficients,
     /// Indicated replacement value is invalid

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -338,6 +338,17 @@ fn raw_operation() {
 }
 
 #[test]
+fn bad_operation() {
+    // We expect this to generate an Unknown value for the
+    // margin fault response rather than an error
+    CommandCode::OPERATION
+        .interpret(&[0b0000_1100], mode, |field, value| {
+            std::println!("{} = {}", field.desc(), value);
+        })
+        .unwrap();
+}
+
+#[test]
 fn page() {
     use commands::PAGE::*;
 


### PR DESCRIPTION
When invalid sentinel values are discovered in the results of a PMBus command, the behavior has historically been to indicate an error for anyone trying to interpret it.  This behavior has proved to be too persnickety: in practice, it's hard for the caller to really do anything with the error, especially because there is no indication of which field was found to have an illegal sentinel or what that sentinel was found to be.  So instead of indicating an InvalidSentinel error, this change uses our existing Unknown variants for invalid sentinels -- which allows for processing to complete on other values, and also makes clear that the sentinal value is unknown.  At the same time, this work adds the OPERATION definition for the ADM1272, a(nother) part that falls into exactly the trap that this work alleviates.