### PR TITLE
Add `SAMPLES_FOR_AVG` to LM5066/i

### DIFF
--- a/src/lm5066.ron
+++ b/src/lm5066.ron
@@ -496,6 +496,13 @@
                 bits: Bitrange(High(95), Low(80)),
                 values: Scalar(Unsigned),
             ),
-        }
+        },
+        "SAMPLES_FOR_AVG": {
+            "AVGN": (
+                name: "log2 of the number of samples for averaging",
+                bits: Bitrange(High(7), Low(0)),
+                values: Scalar(Unsigned),
+            ),
+        },
     },
 )

--- a/src/lm5066i.ron
+++ b/src/lm5066i.ron
@@ -499,6 +499,13 @@
                 bits: Bitrange(High(95), Low(80)),
                 values: Scalar(Unsigned),
             ),
-        }
+        },
+        "SAMPLES_FOR_AVG": {
+            "AVGN": (
+                name: "log2 of the number of samples for averaging",
+                bits: Bitrange(High(7), Low(0)),
+                values: Scalar(Unsigned),
+            ),
+        },
     },
 )


### PR DESCRIPTION
This lets us enable averaging on the Hubris side.