### PR TITLE
Add support for ADM1273

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@ corresponding command data.
 As a concrete example, `commands::OPERATION` contains an implementation
 of the `CommandData` trait for the fields for the common PMBus
 `OPERATION` command.  For each device, there is a device-specific
-`OPERATION` module -- e.g.  `[commands::adm1272::OPERATION]` -- that may
+`OPERATION` module -- e.g.  `[commands::adm127x::OPERATION]` -- that may
 extend or override the common definition.  Further, the device may define
 its own constants; for example, while PMBus defines the command code
-`0xd4` to be `CommandCode::MFR_SPECIFIC_D4`, the ADM1272 defines this to
+`0xd4` to be `CommandCode::MFR_SPECIFIC_D4`, the ADM127x defines this to
 be `PMON_CONFIG`, a device-specific power monitor configuration register.
-There therefore exists a `commands::adm1272::PMON_CONFIG` module that
-understands the full (ADM1272-specific) functionality.  For code that
+There therefore exists a `commands::adm127x::PMON_CONFIG` module that
+understands the full (ADM127x-specific) functionality.  For code that
 wishes to be device agnostic but still be able to display contents, there
 exists a `Device::interpret` that given a device, a code, and a payload,
 calls the specified closure to iterate over fields and values.

--- a/src/adm127x.ron
+++ b/src/adm127x.ron
@@ -47,7 +47,7 @@
     ],
 
     structured: {
-	// The ADM1272 regrettably doesn't support the full PMBus OPERATION
+	// The ADM127x regrettably doesn't support the full PMBus OPERATION
 	// command (it only supports OnOffState) -- and in particular, its
 	// default value of 0x80 corresponds to an illegal value for
 	// MarginFaultResponse (for which only 0b01 and 0b10 are defined

--- a/src/devices.ron
+++ b/src/devices.ron
@@ -1,7 +1,7 @@
 {
-    "adm1272": (
+    "adm127x": (
         manufacturer: "Analog Devices",
-        part: "ADM1272",
+        part: "ADM1272 or ADM1273",
         description: "Postive Hot Swap Controller",
     ),
     "tps546b24a": (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,13 +50,13 @@
 //! As a concrete example, [`commands::OPERATION`] contains an implementation
 //! of the [`CommandData`] trait for the fields for the common PMBus
 //! `OPERATION` command.  For each device, there is a device-specific
-//! `OPERATION` module -- e.g.  `[commands::adm1272::OPERATION]` -- that may
+//! `OPERATION` module -- e.g.  `[commands::adm127x::OPERATION]` -- that may
 //! extend or override the common definition.  Further, the device may define
 //! its own constants; for example, while PMBus defines the command code
-//! `0xd4` to be [`CommandCode::MFR_SPECIFIC_D4`], the ADM1272 defines this to
+//! `0xd4` to be [`CommandCode::MFR_SPECIFIC_D4`], the ADM127x defines this to
 //! be `PMON_CONFIG`, a device-specific power monitor configuration register.
-//! There therefore exists a [`commands::adm1272::PMON_CONFIG`] module that
-//! understands the full (ADM1272-specific) functionality.  For code that
+//! There therefore exists a [`commands::adm127x::PMON_CONFIG`] module that
+//! understands the full (ADM127x-specific) functionality.  For code that
 //! wishes to be device agnostic but still be able to display contents, there
 //! exists a [`Device::interpret`] that given a device, a code, and a payload,
 //! calls the specified closure to iterate over fields and values.  

--- a/tests/core.rs
+++ b/tests/core.rs
@@ -550,8 +550,8 @@ fn verify_status_other() {
 }
 
 #[test]
-fn verify_status_adm1272() {
-    use commands::adm1272::STATUS_MFR_SPECIFIC::*;
+fn verify_status_adm127x() {
+    use commands::adm127x::STATUS_MFR_SPECIFIC::*;
     let data = CommandData::from_slice(&[0x40]).unwrap();
     dump(&data);
 }
@@ -1250,8 +1250,8 @@ fn device_commands() {
 }
 
 #[test]
-fn adm1272_direct() {
-    use commands::adm1272::*;
+fn adm127x_direct() {
+    use commands::adm127x::*;
     use units::*;
 
     let voltage = Coefficients {


### PR DESCRIPTION
The ADM1273 is a drop-in replacement for the ADM1272 (which was EOL'd).