### PR TITLE
bmr491: expose VOUT_UV_FAULT_LIMIT standard register

### DIFF
--- a/src/bmr491.ron
+++ b/src/bmr491.ron
@@ -151,6 +151,7 @@
         ("VIN_OV_WARN_LIMIT", Linear11, Volts),
         ("VIN_UV_WARN_LIMIT", Linear11, Volts),
         ("VIN_UV_FAULT_LIMIT", Linear11, Volts),
+        ("VOUT_UV_FAULT_LIMIT", Linear11, Volts),
         ("TON_DELAY", Linear11, Milliseconds),
         ("TON_RISE", Linear11, Milliseconds),
         ("TON_MAX_FAULT_LIMIT", Linear11, Milliseconds),


### PR DESCRIPTION
I think this just got missed in previous passes, since we haven't relied on it.