### PR TITLE
bmr491: correct VOUT_UV_FAULT_LIMIT units

### DIFF
--- a/src/bmr491.ron
+++ b/src/bmr491.ron
@@ -151,7 +151,7 @@
         ("VIN_OV_WARN_LIMIT", Linear11, Volts),
         ("VIN_UV_WARN_LIMIT", Linear11, Volts),
         ("VIN_UV_FAULT_LIMIT", Linear11, Volts),
-        ("VOUT_UV_FAULT_LIMIT", Linear11, Volts),
+        ("VOUT_UV_FAULT_LIMIT", VOutMode(Unsigned), Volts),
         ("TON_DELAY", Linear11, Milliseconds),
         ("TON_RISE", Linear11, Milliseconds),
         ("TON_MAX_FAULT_LIMIT", Linear11, Milliseconds),


### PR DESCRIPTION
After a more careful reading of the datasheet, this field is VOUT_MODE dependent, not linear volts -- unlike the other UV_FAULT_LIMIT fields!