### PR TITLE
Set channel to latest stable rust (1.95.0)

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.81.0"
+channel = "1.95.0"
 components = ["clippy"]


### PR DESCRIPTION
I'm about to update dependencies and some of them are 2024 edition, which isn't supported by 1.81. I believe I need to update the channel first in a separate PR, so that CI will use 1.95 when building the dependency update PR.