### PR TITLE
Add MWOCP67 PSU

### DIFF
--- a/src/devices.ron
+++ b/src/devices.ron
@@ -35,6 +35,11 @@
         part: "LM5066I",
         description: "Hotswap Controller With I/V/P Monitoring",
     ),
+    "mwocp67": (
+        manufacturer: "Murata",
+        part: "MWOCP67-5500",
+        description: "Front End Power Module"
+    ),
     "mwocp68": (
         manufacturer: "Murata",
         part: "MWOCP68-3600W",

--- a/src/mwocp67.ron
+++ b/src/mwocp67.ron
@@ -18,6 +18,7 @@
         ("PIN_OP_WARN_LIMIT", Linear11, Watts),
         ("READ_VIN", Linear11, Volts),
         ("READ_IIN", Linear11, Amperes),
+        // The datasheet spells this as READ_CAP in some places
         ("READ_VCAP", Linear11, Volts),
         ("READ_VOUT", VOutMode(Unsigned), Volts),
         ("READ_IOUT", Linear11, Amperes),

--- a/src/mwocp67.ron
+++ b/src/mwocp67.ron
@@ -1,0 +1,83 @@
+(
+    all: [
+        (0xc3, "READ_TEMP_CLIP_P", Illegal, ReadWord),
+        (0xc4, "READ_TEMP_CLIP_N", Illegal, ReadWord),
+
+        // TODO: add firmware update commands (https://github.com/oxidecomputer/hubris/issues/2412)
+    ],
+
+    numerics: [
+        ("FAN_COMMAND_1", Linear11, Percent),
+        ("IOUT_OC_FAULT_LIMIT", Linear11, Amperes),
+        ("IOUT_OC_WARN_LIMIT", Linear11, Amperes),
+         // The mwocp67 pmbus doc says IIN_OC_WARN_LIMIT's data format is
+         // "non-numeric" but "input current in amperes" sure sounds numeric to me,
+         // and the value looks reasonable when interpreted as Linear11.
+        ("IIN_OC_WARN_LIMIT", Linear11, Amperes),
+        ("POUT_OP_WARN_LIMIT", Linear11, Watts),
+        ("PIN_OP_WARN_LIMIT", Linear11, Watts),
+        ("READ_VIN", Linear11, Volts),
+        ("READ_IIN", Linear11, Amperes),
+        // TODO mwocp68.ron says that READ_VCAP's format is
+        // `VOutMode(Unsigned)`, but the docs for both the 67 and 68 say it should
+        // be `Linear11`. I should try to test which it is, on both the 67 and 68.
+        ("READ_VCAP", VOutMode(Unsigned), Volts),
+        ("READ_VOUT", VOutMode(Unsigned), Volts),
+        ("READ_IOUT", Linear11, Amperes),
+        ("READ_TEMPERATURE_1", Linear11, Celsius),
+        ("READ_TEMPERATURE_2", Linear11, Celsius),
+        ("READ_TEMPERATURE_3", Linear11, Celsius),
+        ("READ_TEMP_CLIP_P", Linear11, Celsius),
+        ("READ_TEMP_CLIP_N", Linear11, Celsius),
+        ("READ_FAN_SPEED_1", Linear11, Rpm),
+        ("READ_POUT", Linear11, Watts),
+        ("READ_PIN", Linear11, Watts),
+        ("MFR_VIN_MIN", Linear11, Volts),
+        ("MFR_VIN_MAX", Linear11, Volts),
+        ("MFR_IIN_MAX", Linear11, Amperes),
+        ("MFR_PIN_MAX", Linear11, Watts),
+        ("MFR_VOUT_MIN", VOutMode(Unsigned), Volts),
+        ("MFR_VOUT_MAX", VOutMode(Unsigned), Volts),
+        ("MFR_IOUT_MAX", Linear11, Amperes),
+        ("MFR_POUT_MAX", Linear11, Watts),
+        ("MFR_TAMBIENT_MAX", Linear11, Celsius),
+        ("MFR_TAMBIENT_MIN", Linear11, Celsius),
+        ("MFR_MAX_TEMP_1", Linear11, Celsius),
+        ("MFR_MAX_TEMP_2", Linear11, Celsius),
+        ("MFR_MAX_TEMP_3", Linear11, Celsius),
+    ],
+
+    structured: {
+        "STATUS_MFR_SPECIFIC": {
+            "PfcOvervoltageFault": (
+                name: "PFC OV fault occurred",
+                bits: Bit(7),
+                values: Sentinels({
+                    "NoFault": (0b0, "no fault"),
+                    "Fault": (0b1, "fault"),
+                }),
+            ),
+            // Bit 6: undocumented
+            // Bit 5: undocumented
+            "LineStatusChange": (
+                name: "Power supply line status change ",
+                bits: Bit(4),
+                values: Sentinels({
+                    "NoChange": (0b0, "no change"),
+                    "Change": (0b1, "change"),
+                }),
+            ),
+            "PfcUndervoltageFault": (
+                name: "PFC UV fault occurred",
+                bits: Bit(3),
+                values: Sentinels({
+                    "NoFault": (0b0, "no fault"),
+                    "Fault": (0b1, "fault"),
+                }),
+            ),
+            // Bit 2: undocumented
+            // Bit 1: reserved
+            // Bit 0: reserved
+        },
+    }
+)

--- a/src/mwocp67.ron
+++ b/src/mwocp67.ron
@@ -18,10 +18,7 @@
         ("PIN_OP_WARN_LIMIT", Linear11, Watts),
         ("READ_VIN", Linear11, Volts),
         ("READ_IIN", Linear11, Amperes),
-        // TODO mwocp68.ron says that READ_VCAP's format is
-        // `VOutMode(Unsigned)`, but the docs for both the 67 and 68 say it should
-        // be `Linear11`. I should try to test which it is, on both the 67 and 68.
-        ("READ_VCAP", VOutMode(Unsigned), Volts),
+        ("READ_VCAP", Linear11, Volts),
         ("READ_VOUT", VOutMode(Unsigned), Volts),
         ("READ_IOUT", Linear11, Amperes),
         ("READ_TEMPERATURE_1", Linear11, Celsius),

--- a/src/mwocp68.ron
+++ b/src/mwocp68.ron
@@ -52,6 +52,8 @@
         ("PIN_OP_WARN_LIMIT", Linear11, Watts),
         ("READ_VIN", Linear11, Volts),
         ("READ_IIN", Linear11, Amperes),
+        // TODO: READ_VCAP is probably `Linear11` not `VOutMode(Unsigned)`
+        // https://github.com/oxidecomputer/hubris/issues/2543
         ("READ_VCAP", VOutMode(Unsigned), Volts),
         ("READ_VOUT", VOutMode(Unsigned), Volts),
         ("READ_IOUT", Linear11, Amperes),


### PR DESCRIPTION
This adds support for the Observer's MWOCP67 PSU, based on Murata's draft of [acan-157.pdf](https://drive.google.com/file/d/1RhJySiXGmAIxGbF71_MtMJeEWnBKUlBR/view).
Not yet supported:
- Firmware update commands. There's a ticket for that.
- A blackbox feature that looks complicated to use. The old MWOCP68 has a (somewhat different) blackbox feature that we're not using, so I'm guessing there's not much demand for this one either.

This is part of https://github.com/oxidecomputer/pmbus/issues/28