### PR TITLE
Notch out known-unsupported PMBus status registers

### DIFF
--- a/src/adm127x.ron
+++ b/src/adm127x.ron
@@ -2,6 +2,13 @@
     all: [
         (0x01, "OPERATION", WriteByte, ReadByte),
         (0x20, "VOUT_MODE", Illegal, Illegal),
+
+        // These are unsupported, and marked to prevent from automatic queries
+        (0x7e, "STATUS_CML", Illegal, Illegal),
+        (0x7f, "STATUS_OTHER", Illegal, Illegal),
+        (0x81, "STATUS_FANS_1_2", Illegal, Illegal),
+        (0x82, "STATUS_FANS_3_4", Illegal, Illegal),
+
         (0xcc, "RESTART_TIME", WriteByte, ReadByte),
         (0xd0, "PEAK_IOUT", WriteWord, ReadWord),
         (0xd1, "PEAK_VIN", WriteWord, ReadWord),

--- a/src/isl68224.ron
+++ b/src/isl68224.ron
@@ -1,5 +1,10 @@
 (
     all: [
+        // These are unsupported, and marked to prevent from automatic queries
+        (0x7f, "STATUS_OTHER", Illegal, Illegal),
+        (0x81, "STATUS_FANS_1_2", Illegal, Illegal),
+        (0x82, "STATUS_FANS_3_4", Illegal, Illegal),
+
         (0xc5, "DMAFIX", WriteWord32, ReadWord32),
         (0xc6, "DMASEQ", WriteWord32, ReadWord32),
         (0xc7, "DMAADDR", WriteWord, ReadWord),

--- a/src/lm5066.ron
+++ b/src/lm5066.ron
@@ -20,6 +20,11 @@
         (0x2b, "VOUT_MIN", Illegal, Illegal),
         (0xd0, "READ_VAUX", Illegal, ReadWord),
 
+        // These are unsupported, and marked to prevent from automatic queries
+        (0x7b, "STATUS_IOUT", Illegal, Illegal),
+        (0x81, "STATUS_FANS_1_2", Illegal, Illegal),
+        (0x82, "STATUS_FANS_3_4", Illegal, Illegal),
+
         // Why do these four commands have an MFR_ prefix?  Because they
         // conflict with names that PMBus has already defined!  But... why
         // does the device define its own MFR_READ_IIN (say) when it could

--- a/src/lm5066i.ron
+++ b/src/lm5066i.ron
@@ -23,6 +23,11 @@
         (0x2b, "VOUT_MIN", Illegal, Illegal),
         (0xd0, "READ_VAUX", Illegal, ReadWord),
 
+        // These are unsupported, and marked to prevent from automatic queries
+        (0x7b, "STATUS_IOUT", Illegal, Illegal),
+        (0x81, "STATUS_FANS_1_2", Illegal, Illegal),
+        (0x82, "STATUS_FANS_3_4", Illegal, Illegal),
+
         // Why do these four commands have an MFR_ prefix?  Because they
         // conflict with names that PMBus has already defined!  But... why
         // does the device define its own MFR_READ_IIN (say) when it could

--- a/src/mwocp67.ron
+++ b/src/mwocp67.ron
@@ -4,6 +4,15 @@
         (0xc4, "READ_TEMP_CLIP_N", Illegal, ReadWord),
 
         // TODO: add firmware update commands (https://github.com/oxidecomputer/hubris/issues/2412)
+
+        // These registers are read/write by default, but ACAN-157 specifies
+        // that they are read-only.
+        (0x78, "STATUS_BYTE", Illegal, ReadByte),
+        (0x79, "STATUS_WORD", Illegal, ReadWord),
+        (0x7f, "STATUS_OTHER", Illegal, ReadByte),
+
+        // These are unsupported, and marked to prevent from automatic queries
+        (0x82, "STATUS_FANS_3_4", Illegal, Illegal),
     ],
 
     numerics: [

--- a/src/mwocp68.ron
+++ b/src/mwocp68.ron
@@ -1,5 +1,9 @@
 (
     all: [
+        // These are unsupported, and marked to prevent from automatic queries
+        (0x7f, "STATUS_OTHER", Illegal, Illegal),
+        (0x82, "STATUS_FANS_3_4", Illegal, Illegal),
+
         //
         // MFR_PAGE_X allows for reading the black box data: when any fault
         // (except for an input undervoltage) occurs, many values are latched

--- a/src/raa229618.ron
+++ b/src/raa229618.ron
@@ -1,5 +1,10 @@
 (
     all: [
+        // These are unsupported, and marked to prevent from automatic queries
+        (0x7f, "STATUS_OTHER", Illegal, Illegal),
+        (0x81, "STATUS_FANS_1_2", Illegal, Illegal),
+        (0x82, "STATUS_FANS_3_4", Illegal, Illegal),
+
         (0xc5, "DMAFIX", WriteWord32, ReadWord32),
         (0xc6, "DMASEQ", WriteWord32, ReadWord32),
         (0xc7, "DMAADDR", WriteWord, ReadWord),

--- a/src/raa229620a.ron
+++ b/src/raa229620a.ron
@@ -1,5 +1,10 @@
 (
     all: [
+        // These are unsupported, and marked to prevent from automatic queries
+        (0x7f, "STATUS_OTHER", Illegal, Illegal),
+        (0x81, "STATUS_FANS_1_2", Illegal, Illegal),
+        (0x82, "STATUS_FANS_3_4", Illegal, Illegal),
+
         (0xc5, "DMAFIX", WriteWord32, ReadWord32),
         (0xc6, "DMASEQ", WriteWord32, ReadWord32),
         (0xc7, "DMAADDR", WriteWord, ReadWord),

--- a/src/tps546b24a.ron
+++ b/src/tps546b24a.ron
@@ -1,5 +1,9 @@
 (
     all: [
+        // These are unsupported, and marked to prevent from automatic queries
+        (0x81, "STATUS_FANS_1_2", Illegal, Illegal),
+        (0x82, "STATUS_FANS_3_4", Illegal, Illegal),
+
         (0xb1, "COMPENSATION_CONFIG", WriteBlock, ReadBlock),
         (0xb5, "POWER_STAGE_CONFIG", WriteBlock, ReadBlock),
         (0xd0, "TELEMETRY_CONFIG", WriteBlock, ReadBlock),


### PR DESCRIPTION
This PR adds a couple of "Illegal" register definitions for known-absent registers.

https://github.com/oxidecomputer/hubris/pull/2538 begins looking for this information when deciding whether to query this field or not, there will likely be some follow-on PRs to add for more devices.